### PR TITLE
link libgcc_s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endef
 
 define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR) \
-		LIBS="-nodefaultlibs -lgcc -lc -lusb-1.0 -lpthread -luClibc++" \
+		LIBS="-nodefaultlibs -lgcc -lgcc_s -lc -lusb-1.0 -lpthread -luClibc++" \
 		LDFLAGS="$(EXTRA_LDFLAGS)" \
 		CXXFLAGS="$(TARGET_CFLAGS) $(EXTRA_CPPFLAGS)" \
 		$(TARGET_CONFIGURE_OPTS) \


### PR DESCRIPTION
fix undefined references for newer gcc versions
